### PR TITLE
 Add yearly scheduled build for updating year

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 1 1 *'  # yearly build — runs at midnight UTC every Jan 1st
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Current situation: the `{% year %}` shortcode renders the current year at build time:

[https://github.com/aifit/arwanmev2/blob/main/_includes/footer.njk#L5](https://github.com/aifit/arwanmev2/blob/main/_includes/footer.njk#L5)

To keep it up to date automatically, I’m adding a GitHub Actions workflow that runs every January 1st.

No manual edits or extra JS needed.