### PR TITLE
Move GA script inside body tag

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -54,15 +54,15 @@
 
 		{% include "footer.njk" %}
 
+		<!-- Google tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-R7T9E6E9C4"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'G-R7T9E6E9C4');
+		</script>
+
   </body>
-
-	<!-- Google tag (gtag.js) -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=G-R7T9E6E9C4"></script>
-	<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-
-		gtag('config', 'G-R7T9E6E9C4');
-	</script>
 </html>


### PR DESCRIPTION
A `<script>` tag must be placed inside either `<head>` or `<body>`,  putting it between `</body>` and `</html>` is invalid HTML. 

<img width="500" height="110" alt="Screenshot 2025-07-18 at 20 19 29" src="https://github.com/user-attachments/assets/b89af5f6-2879-4d49-9550-20a5cb18df1d" />

Ref:
[https://stackoverflow.com/questions/19958667/stray-start-tag-script](https://stackoverflow.com/questions/19958667/stray-start-tag-script)